### PR TITLE
scaffold: use btn-lg class in generator.

### DIFF
--- a/lib/templates/erb/scaffold/index.html.erb
+++ b/lib/templates/erb/scaffold/index.html.erb
@@ -23,7 +23,7 @@
     </div>
   </div>
   <hr>
-  <%%= link_to new_<%= singular_table_name %>_path, class: 'btn btn-primary btn-large' do %>
+  <%%= link_to new_<%= singular_table_name %>_path, class: 'btn btn-primary btn-lg' do %>
     <%%= icon('plus') %> New
   <%% end %>
 </div>


### PR DESCRIPTION
According to https://v4-alpha.getbootstrap.com/components/buttons/
btn-large is not a valid class.