### PR TITLE
log: extend severities to support standard syslog's.

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -1,12 +1,20 @@
 class Log < ActiveRecord::Base
-  Severities = %w( info debug error )
+  Severities = %w( emerg panic alert crit err warning notice info debug )
 
   validates_presence_of :severity, :message
   validates_inclusion_of :severity, in: Severities
 
+  before_validation :change_severity
+
   after_create :to_syslog if Chaltron.enable_syslog
 
   private
+
+  def change_severity
+    self.severity = :err if self.severity && self.severity.to_sym == :error
+    self.severity = :warning if self.severity && self.severity.to_sym == :warn
+  end
+
   def to_syslog
     syslog_method =
       case self.severity


### PR DESCRIPTION
The deprecated (:error, :warn) are supported as well, but they're
changed on-the-fly to the standard ones.