### PR TITLE
bootstrap_form: make inline option programmable.

### DIFF
--- a/lib/chaltron/bootstrap_form.rb
+++ b/lib/chaltron/bootstrap_form.rb
@@ -5,7 +5,7 @@ class BootstrapForm::FormBuilder
     checked = @object.nil?? false : @object.roles
     html = inputs_collection(:roles, collection, :first, :last, checked: checked) do |name, value, options|
       options[:multiple] = true
-      options[:inline] = true
+      options[:inline] = opts.fetch(:inline, true)
 
       if value == opts[:disabled]
         options[:disabled] = true


### PR DESCRIPTION
When the number of roles is high, the `inline` option makes the form look ugly. Make it programmable.